### PR TITLE
✅ Fix wrong position for note item

### DIFF
--- a/core/ui/src/main/java/com/famy/us/core/ui/Components.kt
+++ b/core/ui/src/main/java/com/famy/us/core/ui/Components.kt
@@ -1,6 +1,5 @@
 package com.famy.us.core.ui
 
-import android.util.Log
 import androidx.compose.foundation.gestures.detectDragGesturesAfterLongPress
 import androidx.compose.foundation.gestures.scrollBy
 import androidx.compose.foundation.layout.Box
@@ -26,7 +25,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.window.Dialog
-import com.famy.us.core.extensions.logD
 import com.famy.us.core.extensions.move
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.MainScope

--- a/feature/note/src/main/java/com/famy/us/feature/note/notescreen/machinestate/states/ItemDraggedState.kt
+++ b/feature/note/src/main/java/com/famy/us/feature/note/notescreen/machinestate/states/ItemDraggedState.kt
@@ -45,7 +45,6 @@ internal class ItemDraggedState<Event : NoteScreenIntent, State : NoteScreenStat
                 try {
                     val fromItem = currentList[from]
                     val toItem = currentList[to]
-
                     machineScope.launch {
                         homeTaskRepository.updateTask(fromItem.copy(position = toItem.position))
                         homeTaskRepository.updateTask(toItem.copy(position = fromItem.position))
@@ -57,7 +56,17 @@ internal class ItemDraggedState<Event : NoteScreenIntent, State : NoteScreenStat
             }
 
             is NoteScreenIntent.StopDrag -> {
-                setMachineState(ItemStateList(currentList))
+                machineScope.launch {
+                    currentList.mapIndexed { index, homeTask ->
+                        val taskUpdated = homeTask.copy(
+                            position = index
+                        )
+                        homeTaskRepository.updateTask(taskUpdated)
+                        taskUpdated
+                    }.also { tasks ->
+                        setMachineState(ItemStateList(tasks))
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
[Root-Cause]: The note position was wrong,
probably because I was testing some fix
to the issue to reorder properly.
[SOLUTION]: Update the position when the
drag action is stopped to guarantee that
they will be sorted properly.