### PR TITLE
✅ Remove done action on Create Note

### DIFF
--- a/feature/note/src/main/java/com/famy/us/feature/note/createNote/components/CreateNoteDescriptionScreen.kt
+++ b/feature/note/src/main/java/com/famy/us/feature/note/createNote/components/CreateNoteDescriptionScreen.kt
@@ -99,13 +99,6 @@ fun SimpleTextField(
         },
         keyboardOptions = KeyboardOptions(
             keyboardType = KeyboardType.Text,
-            imeAction = ImeAction.Done,
-        ),
-        keyboardActions = KeyboardActions(
-            onDone = {
-                focusManager.clearFocus()
-                onDone(text.text)
-            },
         ),
         colors = TextFieldDefaults.colors(
             focusedContainerColor = Color.Transparent,


### PR DESCRIPTION
While user are creating the description
he cant use enter as spaces, so i've
removed the done action to make a space
instead.